### PR TITLE
Add interactive HTML example for letter tiles

### DIFF
--- a/examples/color_tiles.html
+++ b/examples/color_tiles.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+  <meta charset="UTF-8">
+  <title>Kafelki liter</title>
+  <style>
+    body {
+      font-family: sans-serif;
+      background: #f5f5f5;
+      padding: 40px;
+    }
+    #input-area {
+      margin-bottom: 20px;
+    }
+    .row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+    }
+    .tile {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      width: 60px;
+      height: 60px;
+      border-radius: 12px;
+      font-weight: bold;
+      color: white;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+    }
+  </style>
+</head>
+<body>
+  <div id="input-area">
+    <label for="word-input">Wpisz słowo: </label>
+    <input id="word-input" type="text" />
+    <button id="show-word">Pokaż kafelki</button>
+  </div>
+  <div id="tiles" class="row"></div>
+  <script>
+    document.getElementById('show-word').addEventListener('click', function () {
+      const container = document.getElementById('tiles');
+      container.innerHTML = '';
+      const word = document.getElementById('word-input').value.trim().toUpperCase();
+      for (let i = 0; i < word.length; i++) {
+        const ch = word[i];
+        if (/^[A-Z]$/.test(ch)) {
+          const tile = document.createElement('div');
+          tile.className = 'tile';
+          const code = ch.charCodeAt(0) - 64; // A -> 1
+          tile.innerHTML = ch + '<br>' + code;
+          tile.style.backgroundColor = `hsl(${(i * 30) % 360}, 70%, 50%)`;
+          container.appendChild(tile);
+        }
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create examples/color_tiles.html with interactive tiles for any word

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f513b1764832aacc7d3a77fcc95cf